### PR TITLE
add regexes to remove or replace dummy tags during migration

### DIFF
--- a/migration/extract.py
+++ b/migration/extract.py
@@ -414,6 +414,7 @@ def extract_html(entry, shout_id = None, cleanup=False):
         body_clean = cleanup_html(body_orig)
         if body_clean != body_orig:
             print(f"[migration] html cleaned for slug {entry.get('slug', None)}")
+        body_orig = body_clean
     if shout_id:
         extract_footnotes(body_orig, shout_id)
     body_html = str(BeautifulSoup(body_orig, features="html.parser"))

--- a/migration/extract.py
+++ b/migration/extract.py
@@ -251,7 +251,7 @@ def extract_md_images(body, prefix):
     return newbody
 
 
-def cleanup(body):
+def cleanup_md(body):
     newbody = (
         body.replace("<", "")
         .replace(">", "")
@@ -274,7 +274,7 @@ def cleanup(body):
 def extract_md(body, shout_dict = None):
     newbody = body
     if newbody:
-        newbody = cleanup(newbody)
+        newbody = cleanup_md(newbody)
         if not newbody:
             raise Exception("cleanup error")
 
@@ -375,8 +375,45 @@ def prepare_html_body(entry):
     return body
 
 
-def extract_html(entry, shout_id = None):
+def cleanup_html(body: str) -> str:
+    new_body = body
+    regex_remove = [
+        r"style=\"width:\s*\d+px;height:\s*\d+px;\"",
+        r"style=\"width:\s*\d+px;\"",
+        r"style=\"color: #000000;\"",
+        r"style=\"float: none;\"",
+        r"style=\"background: white;\"",
+        r"class=\"Apple-interchange-newline\"",
+        r"class=\"MsoNormalCxSpMiddle\"",
+        r"class=\"MsoNormal\"",
+        r"lang=\"EN-US\"",
+        r"id=\"docs-internal-guid-[\w-]+\"",
+        r"<p></p>",
+        r"<span></span>",
+        r"<i></i>",
+        r"<b></b>",
+        r"<h1></h1>",
+        r"<h2></h2>",
+        r"<h3></h3>",
+        r"<h4></h4>",
+        r"<div></div>",
+    ]
+    regex_replace = {
+        r"<br></p>": "</p>"
+    }
+    for regex in regex_remove:
+        new_body = re.sub(regex, "", new_body)
+    for regex, replace in regex_replace.items():
+        new_body = re.sub(regex, replace, new_body)
+    return new_body
+
+def extract_html(entry, shout_id = None, cleanup=False):
     body_orig = (entry.get("body") or "").replace('\(', '(').replace('\)', ')')
+    if cleanup:
+        # we do that before bs parsing to catch the invalid html
+        body_clean = cleanup_html(body_orig)
+        if body_clean != body_orig:
+            print(f"[migration] html cleaned for slug {entry.get('slug', None)}")
     if shout_id:
         extract_footnotes(body_orig, shout_id)
     body_html = str(BeautifulSoup(body_orig, features="html.parser"))

--- a/migration/tables/content_items.py
+++ b/migration/tables/content_items.py
@@ -150,7 +150,7 @@ async def migrate(entry, storage):
         "createdAt": date_parse(entry.get("createdAt", OLD_DATE)),
         "updatedAt": date_parse(entry["updatedAt"]) if "updatedAt" in entry else ts,
         "topics": await add_topics_follower(entry, storage, author),
-        "body": extract_html(entry)
+        "body": extract_html(entry, cleanup=True)
     }
 
     # main topic patch


### PR DESCRIPTION
First part of improving the migration process by cleaning the redundant HTML tags.

Remove dummy tags:
* `style="width: Xpx;height: Ypx;"`
* `style="width: Xpx;"`
* `style="color: #000000;"`
* `style="float: none;"`
* `style="background: white;"`
* `class="Apple-interchange-newline"`
* `class="MsoNormalCxSpMiddle"`
* `class="MsoNormal"`
* `lang="EN-US"`
* `<p></p>` etc
* `id="docs-internal-guid-..."`

Replace tags:
`<br></p>` replaced with `</p>`

A better approach would probably involve `bs4` HTML parsers. 
Here we won't catch stuff like `style="something useful; float: none;"` but do we want to?
